### PR TITLE
修复了插件无法使用的问题，这个原因是，imageOps.js的一个import 少了一个空格，不知道其他人有没有遇到这个问题，可能是使用平…

### DIFF
--- a/core/imageOps.js
+++ b/core/imageOps.js
@@ -2,7 +2,7 @@
  * Created by buhe on 16/4/12.
  */
 import util from './auth';
-import rpc from'./rpc';
+import rpc from './rpc';
 import conf from './conf';
 
 class ImageView {


### PR DESCRIPTION
修复了插件无法使用的问题，这个原因是，imageOps.js的一个import 少了一个空格，不知道其他人有没有遇到这个问题，可能是使用平台的问题，或者rn的版本问题。